### PR TITLE
The output of fdisk is languaje dependant. 

### DIFF
--- a/colcon_acceleration/subverb/__init__.py
+++ b/colcon_acceleration/subverb/__init__.py
@@ -390,7 +390,7 @@ def mount_rawimage(rawimage_path, partition=1, debug=False):
 
     # fetch UNITS
     units = None
-    cmd = "fdisk -l " + rawimage_path + " | grep 'Units' | awk '{print $8}'"
+    cmd = "fdisk -l " + rawimage_path + " | grep "[Units|Unidades]" | awk '{print $8}'"
     outs, errs = run(cmd, shell=True)
     if outs:
         units = int(outs)

--- a/colcon_acceleration/subverb/emulation.py
+++ b/colcon_acceleration/subverb/emulation.py
@@ -251,7 +251,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
         if not context.args.no_install:
             # fetch UNITS
             units = None
-            cmd = "fdisk -l " + rawimage_path + " | grep 'Units' | awk '{print $8}'"
+            cmd = "fdisk -l " + rawimage_path + " | grep "[Units|Unidades]" | awk '{print $8}'"
             outs, errs = run(cmd, shell=True)
             if outs:
                 units = int(outs)


### PR DESCRIPTION
Added spanish "Unidades" to the scripts to work on Spanish/Latin America linux distributions

/colcon-acceleration/subverb/__init__.py line 393: changed <grep 'Units'> to <grep "[Units|Unidades]"> to manage fdisk spanish output also
/colcon-acceleration/subverb/emulation.py line 254: changed <grep 'Units'> to <grep "[Units|Unidades]"> to manage fdisk spanish output also