### PR TITLE
Syntax error in fdisk_issue patch

### DIFF
--- a/colcon_acceleration/subverb/__init__.py
+++ b/colcon_acceleration/subverb/__init__.py
@@ -390,7 +390,7 @@ def mount_rawimage(rawimage_path, partition=1, debug=False):
 
     # fetch UNITS
     units = None
-    cmd = "fdisk -l " + rawimage_path + " | grep '[Units|Unidades]' | awk '{print $8}'"
+    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
     outs, errs = run(cmd, shell=True)
     if outs:
         units = int(outs)
@@ -662,7 +662,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
 
     # fetch UNITS
     units = None
-    cmd = "fdisk -l " + rawimage_path + " | grep 'Units' | awk '{print $8}'"
+    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
     outs, errs = run(cmd, shell=True)
     if outs:
         units = int(outs)

--- a/colcon_acceleration/subverb/emulation.py
+++ b/colcon_acceleration/subverb/emulation.py
@@ -251,7 +251,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
         if not context.args.no_install:
             # fetch UNITS
             units = None
-            cmd = "fdisk -l " + rawimage_path + " | grep '[Units|Unidades]' | awk '{print $8}'"
+            cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
             outs, errs = run(cmd, shell=True)
             if outs:
                 units = int(outs)


### PR DESCRIPTION
Replaced double quotes with single quotes in grep command and added backslash to search for the two words

colcon-acceleration/subverb/__init__.py line 393: changed <grep "[Units|Unidades]"> to <grep 'Units\|Unidades'> due to a syntax error
colcon-acceleration/subverb/__init__.py line 665: changed <grep 'Units'> to <grep 'Units\|Unidades'> to build zcu102 image
colcon-acceleration/subverb/emulation.py line 254: changed <grep "[Units|Unidades]"> to <grep 'Units\|Unidades'> due to a syntax error

Sorry for the mistake :-(